### PR TITLE
Refactor: Simplify validation by using direct input types in mutations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.2",
         "bcrypt": "^5.1.1",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "graphql": "^16.9.0",
         "reflect-metadata": "^0.2.0",
@@ -4092,6 +4093,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.0.tgz",
       "integrity": "sha512-N1NGmowPlGBLsOZLPvm48StN04V4YvQRL0i6b7ctrVY3epjP/ct7hFLOItz6pDIvRjwpfPxi52a2UWV2ziir8g==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.2",
     "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "graphql": "^16.9.0",
     "reflect-metadata": "^0.2.0",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -4,6 +4,6 @@ import { Controller, Get } from '@nestjs/common';
 export class AppController {
   @Get('/')
   getRoot(): string {
-    return 'Server Running by Luan';
+    return '🪼 GraphQL Server Running';
   }
 }

--- a/src/graphql/inputs/create-user.input.ts
+++ b/src/graphql/inputs/create-user.input.ts
@@ -1,21 +1,26 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, MinLength, IsString } from 'class-validator';
 
 @InputType()
-export class CreateUserInput { //defino a estrutura de dados que será passada para a mutation
+export class CreateUserInput {
+  // Defino a estrutura de dados que será passada para a mutation
+
   @Field()
-  @IsNotEmpty()
+  @IsString({ message: 'The name must be a string.' })
+  @IsNotEmpty({ message: 'The name cannot be empty.' })
   name: string;
 
   @Field()
-  @IsEmail()
+  @IsEmail({}, { message: 'The email must be a valid email address.' })
   email: string;
 
   @Field()
-  @MinLength(6)
+  @MinLength(6, { message: 'The password must be at least 6 characters long.' })
   password: string;
 
   @Field()
-  @MinLength(6)
+  @MinLength(6, {
+    message: 'The confirmation password must be at least 6 characters long.',
+  })
   confirmPassword: string;
 }

--- a/src/graphql/resolver/user.resolver.ts
+++ b/src/graphql/resolver/user.resolver.ts
@@ -1,7 +1,7 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateUserArgs } from '../args/create-user.args';
+import { CreateUserInput } from '../inputs/create-user.input';
 import { User } from '../objects/user.object';
 import * as bcrypt from 'bcrypt';
 import { UpdateUserInput } from '../inputs/update-user.input';
@@ -19,18 +19,15 @@ export class UserResolver { //logica geral da aplicação
   }
 
   @Mutation(() => Number)
-  async createUser(@Args() args: CreateUserArgs): Promise<number> {
-    const { name, email, password, confirmPassword } = args.data;
+  async createUser(@Args('data') data: CreateUserInput): Promise<number> {
+    const { name, email, password, confirmPassword } = data;
 
-    // Valida se a senha e a confirmação são iguais
     if (password !== confirmPassword) {
       throw new Error('Password and confirm password do not match');
     }
 
-    // Criptografa a senha
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    // Cria um novo usuário
     const newUser = this.userRepository.create({
       name,
       email,
@@ -54,11 +51,9 @@ export class UserResolver { //logica geral da aplicação
         throw new Error('Password and confirm password do not match');
       }
 
-      // Criptografa a nova senha
       data.password = await bcrypt.hash(data.password, 10);
     }
 
-    // Remover confirmPassword do objeto antes de atualizar o banco de dados (talvez nao seja a melhor abordagem)
     const { confirmPassword, ...updateData } = data;
 
     await this.userRepository.update(data.id, updateData);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  
+  app.useGlobalPipes(new ValidationPipe());
   // Habilitar CORS com configurações básicas (Não sei se é a melhor abordagem)
   app.enableCors({
     origin: '*', // Permite qualquer origem.


### PR DESCRIPTION
Este PR faz uma refatoração significativa no processo de criação e atualização de usuários na API GraphQL. As principais alterações incluem:

Refatoração da Lógica de Validação: Simplificamos o código eliminando a necessidade de uma classe intermediária (CreateUserArgs) e agora usamos diretamente os tipos de entrada (CreateUserInput e UpdateUserInput) nas mutações createUser e updateUser. Isso garante que as validações definidas com class-validator sejam aplicadas corretamente.

Correção de Validações: Abordamos um problema em que as validações do class-validator não estavam sendo aplicadas corretamente ao criar ou atualizar usuários. A refatoração garante que as validações sejam executadas conforme esperado.

Melhorias Gerais: O código agora é mais simples, direto e fácil de manter, com as validações funcionando conforme o esperado.

Tristeza:
Levei aproximadamente 3 horas para identificar e resolver o problema relacionado à falta de aplicação das validações nos inputs, incluindo testes e verificações adicionais para garantir que tudo funcionasse corretamente após a refatoração.

![image](https://github.com/user-attachments/assets/92e41dd1-cd64-44af-950a-b88ee7543ba9)